### PR TITLE
Add support for view collections

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ pocketbase_utils:
   output_dir: lib/generated/pocketbase # Optional. Sets the directory of generated model files. If the directory doesn't exist — it'll be created. Default: lib/generated/pocketbase
   line_length: 80 # Optional. Sets the length of line for dart formatter of generated code. Default: 80
   generate_system_collections: false # Optional. Generate models for the system level collections like `_mfas`, `_otps`, and `_superusers`. Default: false
+  generate_view_collections: false # Optional. Generate models for the view type collections. Default: false
 ```
 
 ### 4. Run the generator

--- a/lib/src/config/pubspec_config.dart
+++ b/lib/src/config/pubspec_config.dart
@@ -25,12 +25,16 @@ class PubspecConfig {
     }
 
     _enabled = pocketbaseUtilsConfig['enabled'] is bool ? pocketbaseUtilsConfig['enabled'] as bool : null;
-    _pbSchemaPath =
-        pocketbaseUtilsConfig['pb_schema_path'] is String ? pocketbaseUtilsConfig['pb_schema_path'] as String : null;
+    _pbSchemaPath = pocketbaseUtilsConfig['pb_schema_path'] is String
+        ? pocketbaseUtilsConfig['pb_schema_path'] as String
+        : null;
     _outputDir = pocketbaseUtilsConfig['output_dir'] is String ? pocketbaseUtilsConfig['output_dir'] as String : null;
     _lineLength = pocketbaseUtilsConfig['line_length'] is int ? pocketbaseUtilsConfig['line_length'] as int : null;
     _generateSystemCollections = pocketbaseUtilsConfig['generate_system_collections'] is bool
         ? pocketbaseUtilsConfig['generate_system_collections'] as bool
+        : null;
+    _generateViewCollections = pocketbaseUtilsConfig['generate_view_collections'] is bool
+        ? pocketbaseUtilsConfig['generate_view_collections'] as bool
         : null;
   }
 
@@ -39,6 +43,7 @@ class PubspecConfig {
   String? _outputDir;
   int? _lineLength;
   bool? _generateSystemCollections;
+  bool? _generateViewCollections;
 
   bool? get enabled => _enabled;
 
@@ -49,4 +54,6 @@ class PubspecConfig {
   int? get lineLength => _lineLength;
 
   bool? get generateSystemCollections => _generateSystemCollections;
+
+  bool? get generateViewCollections => _generateViewCollections;
 }

--- a/lib/src/generator/generator.dart
+++ b/lib/src/generator/generator.dart
@@ -18,6 +18,7 @@ const _defaultPbSchemaPath = 'pb_schema.json';
 const _defaultOutputDir = 'lib/generated/pocketbase';
 const _defaultLineLength = 80;
 const _defaultGenerateSystemCollections = false;
+const _defaultGenerateViewCollections = false;
 
 /// The generator of models files.
 class Generator {
@@ -42,11 +43,13 @@ class Generator {
     _lineLength = pubspecConfig.lineLength ?? _defaultLineLength;
 
     _generateSystemCollections = pubspecConfig.generateSystemCollections ?? _defaultGenerateSystemCollections;
+    _generateViewCollections = pubspecConfig.generateViewCollections ?? _defaultGenerateViewCollections;
   }
   late String _pbSchemaPath;
   late String _outputDir;
   late int _lineLength;
   late bool _generateSystemCollections;
+  late bool _generateViewCollections;
 
   /// Generates collections models files.
   Future<void> generateAsync() async {
@@ -74,6 +77,10 @@ class Generator {
     return Directory(outputDirPath).create(recursive: true);
   }
 
+  bool _isCollectionEnabled(Collection collection) =>
+      (_generateSystemCollections || !collection.system) &&
+      (_generateViewCollections || collection.type != CollectionType.view);
+
   Future<void> _generateDartFiles(File pbSchemaFile, Directory outputDirectory) async {
     final pbSchemaFileContent = pbSchemaFile.readAsStringSync();
     final pbSchemaDecoded = jsonDecode(pbSchemaFileContent);
@@ -88,7 +95,7 @@ class Generator {
       }
 
       final collectionModel = Collection.fromJson(collectionJson);
-      if (_generateSystemCollections || !collectionModel.system) {
+      if (_isCollectionEnabled(collectionModel)) {
         collections.add(collectionModel);
       }
     }

--- a/lib/src/generator/generator.dart
+++ b/lib/src/generator/generator.dart
@@ -9,6 +9,7 @@ import 'package:pocketbase_utils/src/templates/base_record.dart';
 import 'package:pocketbase_utils/src/templates/date_time_json_methods.dart';
 import 'package:pocketbase_utils/src/templates/empty_values.dart';
 import 'package:pocketbase_utils/src/templates/geo_point_class.dart';
+import 'package:pocketbase_utils/src/templates/view_record.dart';
 import 'package:pocketbase_utils/src/utils/file_utils.dart';
 import 'package:pocketbase_utils/src/utils/utils.dart';
 import 'package:recase/recase.dart';
@@ -99,6 +100,10 @@ class Generator {
     createFileAndWrite(
       path.join(outputDirectory.path, 'auth_record.dart'),
       authRecordClassGenerator(_lineLength),
+    );
+    createFileAndWrite(
+      path.join(outputDirectory.path, 'view_record.dart'),
+      viewRecordClassGenerator(_lineLength),
     );
     createFileAndWrite(
       path.join(outputDirectory.path, 'empty_values.dart'),

--- a/lib/src/schema/collection/collection.dart
+++ b/lib/src/schema/collection/collection.dart
@@ -4,6 +4,7 @@ import 'package:dart_style/dart_style.dart';
 import 'package:json_annotation/json_annotation.dart';
 import 'package:pocketbase_utils/src/schema/field.dart';
 import 'package:pocketbase_utils/src/templates/do_not_modify_by_hand.dart';
+import 'package:pocketbase_utils/src/templates/view_record.dart';
 import 'package:pocketbase_utils/src/utils/code_builder.dart';
 import 'package:recase/recase.dart';
 
@@ -65,7 +66,8 @@ final class Collection {
         /// We override the "email" field to a non-nullable one in case when
         /// the schema has both "email" and "emailVisibility" fields set to "required"
         /// because otherwise it can be hidden from the API response or be null.
-        final isEmailFieldInSchemaRequired = fields.firstWhereOrNull((e) => e.name == 'email')?.required == true &&
+        final isEmailFieldInSchemaRequired =
+            fields.firstWhereOrNull((e) => e.name == 'email')?.required == true &&
             fields.firstWhereOrNull((e) => e.name == 'emailVisibility')?.required == true;
 
         if (isEmailFieldInSchemaRequired) {
@@ -80,7 +82,8 @@ final class Collection {
           superFields.addAll(authFields);
         }
       case CollectionType.view:
-        return '';
+        extend = code_builder.refer('ViewRecord', 'view_record.dart');
+        superFields.addAll(viewFields);
     }
 
     final fieldsWithoutSuperFields = fields.whereNot((f) => superFields.any((sf) => sf.name == f.name)).toList();
@@ -102,15 +105,19 @@ final class Collection {
               ..name = 'nameInSchema'
               ..modifier = code_builder.FieldModifier.final$
               ..type = code_builder.refer('String'),
-          )
+          ),
         ])
         ..constructors.add(
           code_builder.Constructor(
             (co) => co
               ..constant = true
-              ..requiredParameters.add(code_builder.Parameter((p) => p
-                ..toThis = true
-                ..name = 'nameInSchema')),
+              ..requiredParameters.add(
+                code_builder.Parameter(
+                  (p) => p
+                    ..toThis = true
+                    ..name = 'nameInSchema',
+                ),
+              ),
           ),
         )
         ..values.addAll([
@@ -132,8 +139,9 @@ final class Collection {
     );
 
     final enumSelectValuesCode = [
-      for (final field
-          in allFieldsWithoutHidden.where((f) => f.type == FieldType.select && f.values?.isNotEmpty == true))
+      for (final field in allFieldsWithoutHidden.where(
+        (f) => f.type == FieldType.select && f.values?.isNotEmpty == true,
+      ))
         code_builder.Enum(
           (e) => e
             ..name = field.enumTypeName(className)
@@ -143,28 +151,34 @@ final class Collection {
                   ..name = 'nameInSchema'
                   ..modifier = code_builder.FieldModifier.final$
                   ..type = code_builder.refer('String'),
-              )
+              ),
             ])
             ..constructors.add(
               code_builder.Constructor(
                 (co) => co
                   ..constant = true
-                  ..requiredParameters.add(code_builder.Parameter((p) => p
-                    ..toThis = true
-                    ..name = 'nameInSchema')),
+                  ..requiredParameters.add(
+                    code_builder.Parameter(
+                      (p) => p
+                        ..toThis = true
+                        ..name = 'nameInSchema',
+                    ),
+                  ),
               ),
             )
             ..values.addAll([
               if (field.values != null)
                 for (final value in field.values!)
-                  code_builder.EnumValue((ev) => ev
-                    ..name = ReCase(value).camelCase
-                    ..arguments.add(code_builder.literalString(value))
-                    ..annotations.add(
-                      code_builder
-                          .refer('JsonValue', 'package:json_annotation/json_annotation.dart')
-                          .newInstance([code_builder.literalString(value)]),
-                    )),
+                  code_builder.EnumValue(
+                    (ev) => ev
+                      ..name = ReCase(value).camelCase
+                      ..arguments.add(code_builder.literalString(value))
+                      ..annotations.add(
+                        code_builder.refer('JsonValue', 'package:json_annotation/json_annotation.dart').newInstance([
+                          code_builder.literalString(value),
+                        ]),
+                      ),
+                  ),
             ]),
         ),
     ];
@@ -174,14 +188,21 @@ final class Collection {
         ..name = className
         ..extend = extend
         ..modifier = code_builder.ClassModifier.final$
-        ..annotations
-            .add(code_builder.refer('JsonSerializable', 'package:json_annotation/json_annotation.dart').newInstance([]))
+        ..annotations.add(
+          code_builder.refer('JsonSerializable', 'package:json_annotation/json_annotation.dart').newInstance([]),
+        )
         ..fields.addAll([
           for (final field in fieldsWithoutSuperFieldsAndHidden) ...[
-            field.toCodeBuilder(
-              className,
-              shouldOverride: fieldsToOverride.any((e) => e.name == field.name),
-            ),
+            if (type == CollectionType.view)
+              field.toCodeBuilderForView(
+                className,
+                shouldOverride: fieldsToOverride.any((e) => e.name == field.name),
+              )
+            else
+              field.toCodeBuilder(
+                className,
+                shouldOverride: fieldsToOverride.any((e) => e.name == field.name),
+              ),
             ...field.additionalFieldOptionsAsFields(),
           ],
           for (final staticCollectionRefFieldName in ['collectionId', 'collectionName'])
@@ -190,13 +211,11 @@ final class Collection {
                 ..name = '\$$staticCollectionRefFieldName'
                 ..static = true
                 ..modifier = code_builder.FieldModifier.constant
-                ..assignment = code_builder
-                    .literalString(switch (staticCollectionRefFieldName) {
-                      'collectionName' => name,
-                      'collectionId' => id,
-                      _ => '',
-                    })
-                    .code,
+                ..assignment = code_builder.literalString(switch (staticCollectionRefFieldName) {
+                  'collectionName' => name,
+                  'collectionId' => id,
+                  _ => '',
+                }).code,
             ),
         ])
         ..constructors.addAll([
@@ -206,10 +225,10 @@ final class Collection {
         ])
         ..methods.addAll([
           _toJsonMethod(className),
-          _copyWithMethod(className, allFieldsWithoutHidden),
+          _copyWithMethod(className, allFieldsWithoutHidden, type),
           _takeDiffMethod(className, allFieldsWithoutHidden),
           _propsMethod(fieldsWithoutSuperFieldsAndHidden),
-          _forCreateRequestMethod(className, allFieldsWithoutHidden),
+          if (type != CollectionType.view) _forCreateRequestMethod(className, allFieldsWithoutHidden),
         ]),
     );
 

--- a/lib/src/schema/collection/methods/copy_with.dart
+++ b/lib/src/schema/collection/methods/copy_with.dart
@@ -1,6 +1,6 @@
 part of '../collection.dart';
 
-code_builder.Method _copyWithMethod(String className, Iterable<Field> allFieldsExceptHidden) {
+code_builder.Method _copyWithMethod(String className, Iterable<Field> allFieldsExceptHidden, CollectionType collectionType) {
   return code_builder.Method((m) => m
     ..returns = code_builder.refer(className)
     ..name = 'copyWith'
@@ -9,7 +9,9 @@ code_builder.Method _copyWithMethod(String className, Iterable<Field> allFieldsE
         code_builder.Parameter((p) => p
           ..named = true
           ..name = field.nameInCamelCase
-          ..type = field.fieldTypeRef(className, forceNullable: true)),
+          ..type = collectionType == CollectionType.view
+              ? code_builder.refer('dynamic')
+              : field.fieldTypeRef(className, forceNullable: true)),
     ])
     ..body = code_builder.Block(
       (bb) => bb
@@ -17,9 +19,9 @@ code_builder.Method _copyWithMethod(String className, Iterable<Field> allFieldsE
           code_builder
               .refer(className)
               .newInstance([], {
-                for (final baseField in baseFields)
+                for (final baseField in collectionType == CollectionType.view ? viewFields : baseFields)
                   baseField.nameInCamelCase: code_builder.refer(baseField.nameInCamelCase),
-                for (final field in allFieldsExceptHidden.where((f) => !baseFields.contains(f)))
+                for (final field in allFieldsExceptHidden.where((f) => !(collectionType == CollectionType.view ? viewFields : baseFields).contains(f)))
                   field.nameInCamelCase:
                       code_builder.refer('${field.nameInCamelCase} ?? this.${field.nameInCamelCase}'),
               })

--- a/lib/src/schema/field.dart
+++ b/lib/src/schema/field.dart
@@ -148,7 +148,7 @@ final class Field {
     });
   }
 
-    /// Creates a field with dynamic type for view collections.
+  /// Creates a field with dynamic type for view collections.
   /// All fields in view collections should be dynamic since they can contain
   /// aggregated data from multiple collections with different types.
   code_builder.Field toCodeBuilderForView(String className, {bool shouldOverride = false}) {

--- a/lib/src/schema/field.dart
+++ b/lib/src/schema/field.dart
@@ -148,6 +148,24 @@ final class Field {
     });
   }
 
+    /// Creates a field with dynamic type for view collections.
+  /// All fields in view collections should be dynamic since they can contain
+  /// aggregated data from multiple collections with different types.
+  code_builder.Field toCodeBuilderForView(String className, {bool shouldOverride = false}) {
+    return code_builder.Field((f) {
+      final jsonAnnotation = _jsonAnnotation(className);
+
+      f
+        ..name = nameInCamelCase
+        ..modifier = code_builder.FieldModifier.final$
+        ..type = fieldTypeRef(className)
+        ..annotations.addAll([
+          if (jsonAnnotation != null) jsonAnnotation,
+          if (shouldOverride) code_builder.refer('override'),
+        ]);
+    });
+  }
+
   List<code_builder.Field> additionalFieldOptionsAsFields() {
     return [
       if (min != null)

--- a/lib/src/templates/view_record.dart
+++ b/lib/src/templates/view_record.dart
@@ -1,0 +1,108 @@
+import 'package:code_builder/code_builder.dart' as code_builder;
+import 'package:dart_style/dart_style.dart';
+import 'package:pocketbase_utils/src/schema/field.dart';
+import 'package:pocketbase_utils/src/templates/do_not_modify_by_hand.dart';
+
+/// Base class for PocketBase view collection records.
+/// Views are read-only collections that aggregate data from other collections.
+abstract base class ViewRecord {
+  const ViewRecord({
+    required this.id,
+    required this.collectionId,
+    required this.collectionName,
+  });
+
+  /// The unique identifier of the record.
+  final String id;
+
+  /// The identifier of the collection this record belongs to.
+  final String collectionId;
+
+  /// The name of the collection this record belongs to.
+  final String collectionName;
+
+  /// Override this in subclasses to provide props for Equatable
+  List<Object?> get props => [id, collectionId, collectionName];
+}
+
+/// Fields that are available on all view records.
+const viewFields = [
+  Field(
+    name: 'id',
+    type: FieldType.text,
+    required: true,
+    system: true,
+  ),
+  Field(
+    name: 'collectionId',
+    type: FieldType.text,
+    required: true,
+    system: true,
+  ),
+  Field(
+    name: 'collectionName',
+    type: FieldType.text,
+    required: true,
+    system: true,
+  ),
+];
+
+String viewRecordClassGenerator(int lineLength) {
+  const className = 'ViewRecord';
+
+  final classCode = code_builder.Class(
+    (c) => c
+      ..name = className
+      ..abstract = true
+      ..modifier = code_builder.ClassModifier.base
+      ..extend = code_builder.refer('Equatable', 'package:equatable/equatable.dart')
+      ..fields.addAll([
+        for (final field in viewFields) field.toCodeBuilder(className),
+      ])
+      ..constructors.addAll([
+        code_builder.Constructor((d) => d
+          ..constant = true
+          ..optionalParameters.addAll([
+            for (final field in viewFields)
+              code_builder.Parameter(
+                (p) => p
+                  ..toThis = true
+                  ..name = field.nameInCamelCase
+                  ..named = true
+                  ..required = field.isNonNullable,
+              ),
+          ])),
+      ])
+      ..methods.addAll([
+        code_builder.Method((m) => m
+          ..annotations.add(code_builder.refer('override'))
+          ..returns = code_builder.refer('List<Object?>')
+          ..type = code_builder.MethodType.getter
+          ..name = 'props'
+          ..lambda = true
+          ..body = code_builder.literalList([
+            for (final field in viewFields) code_builder.refer(field.nameInCamelCase),
+          ]).code),
+      ]),
+  );
+
+  final libraryCode = code_builder.Library(
+    (l) => l
+      ..body.add(classCode)
+      ..generatedByComment = doNotModifyByHandTemplate
+      ..ignoreForFile.add('unused_import')
+      ..directives.addAll([
+        code_builder.Directive.import('package:json_annotation/json_annotation.dart'),
+      ]),
+  );
+
+  final emitter = code_builder.DartEmitter.scoped(
+    useNullSafetySyntax: true,
+    orderDirectives: true,
+  );
+
+  return DartFormatter(
+    languageVersion: DartFormatter.latestShortStyleLanguageVersion,
+    pageWidth: lineLength,
+  ).format('${libraryCode.accept(emitter)}');
+}


### PR DESCRIPTION
Taking inspiration from Fanom2813 work, I added support for view collections.
This fixes issue #7.

Models from view collections can be fully typed using a CAST in the view query. For example a `CAST(example AS REAL) AS example` generates a model with a field like `double? example;` (maybe we can add this to the README?).

I also added a new configuration option to enable/disable view collections and updated the README accordingly.